### PR TITLE
Exercice : ajout des auteurs

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -2,4 +2,44 @@ class AuthorsController < ApplicationController
   def index
     @authors = Author.all
   end
+
+  def edit
+    @author = Author.find(params[:id])
+  end
+
+  def new
+    @author = Author.new
+  end
+
+  def create
+    @author = Author.new(author_params)
+    if @author.save
+      redirect_to [ :edit, @author ], notice: "Author created!"
+    else
+      flash.now[:alert] = "Failed to create author!"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @author = Author.find(params[:id])
+    if @author.update(author_params)
+      redirect_to [ :edit, @author ], notice: "Author updated!"
+    else
+      flash.now[:alert] = "Failed to update author!"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @author = Author.find(params[:id])
+    @author.destroy
+    redirect_to [ :authors ]
+  end
+
+  private
+
+  def author_params
+    params.require(:author).permit(:name)
+  end
 end

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -16,7 +16,7 @@ class AuthorsController < ApplicationController
     if @author.save
       respond_to do |format|
         format.html { redirect_to [ :edit, @author ], notice: "Author created!" }
-        format.turbo_stream
+        format.turbo_stream { render turbo_stream: turbo_stream.append("authors", @author) }
       end
     else
       flash.now[:alert] = "Failed to create author!"

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -14,7 +14,10 @@ class AuthorsController < ApplicationController
   def create
     @author = Author.new(author_params)
     if @author.save
-      redirect_to [ :edit, @author ], notice: "Author created!"
+      respond_to do |format|
+        format.html { redirect_to [ :edit, @author ], notice: "Author created!" }
+        format.turbo_stream
+      end
     else
       flash.now[:alert] = "Failed to create author!"
       render :new, status: :unprocessable_entity

--- a/app/views/authors/_author.html.haml
+++ b/app/views/authors/_author.html.haml
@@ -1,0 +1,6 @@
+.row.d-flex.border-bottom.py-3
+  .col.fw-bold= author.id
+  .col= author.name
+  .col.d-flex.gap-2
+    = link_to "edit", [ :edit, author ], class: "link-primary"
+    = link_to "destroy", [ author ], class: "link-danger", data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }

--- a/app/views/authors/_form.html.haml
+++ b/app/views/authors/_form.html.haml
@@ -1,0 +1,8 @@
+= form_with model: author do |form|
+  .mb-3
+    = form.label :name, class: "form-label"
+    = form.text_field :name, class: "form-control"
+    - if author.errors[:name].any?
+      %p.text-danger= author.errors[:name].join(", ")
+
+  = form.submit class: "btn btn-primary"

--- a/app/views/authors/_form.html.haml
+++ b/app/views/authors/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: author do |form|
+= form_with model: author, data: { turbo_frame: '_top' } do |form|
   .mb-3
     = form.label :name, class: "form-label"
     = form.text_field :name, class: "form-control"

--- a/app/views/authors/create.turbo_stream.haml
+++ b/app/views/authors/create.turbo_stream.haml
@@ -1,0 +1,7 @@
+%turbo-stream{ action: "append", target: "authors" }
+  %template
+    .row.d-flex.border-bottom.py-3
+      .col.fw-bold= @author.id
+      .col= @author.name
+      .col.d-flex.gap-2
+        = link_to "edit", [ :edit, @author ], class: "link-primary"

--- a/app/views/authors/create.turbo_stream.haml
+++ b/app/views/authors/create.turbo_stream.haml
@@ -1,7 +1,0 @@
-%turbo-stream{ action: "append", target: "authors" }
-  %template
-    .row.d-flex.border-bottom.py-3
-      .col.fw-bold= @author.id
-      .col= @author.name
-      .col.d-flex.gap-2
-        = link_to "edit", [ :edit, @author ], class: "link-primary"

--- a/app/views/authors/edit.html.haml
+++ b/app/views/authors/edit.html.haml
@@ -1,0 +1,7 @@
+%nav{aria: { label: "breadcrumb" } }
+  %ol.breadcrumb
+    %li.breadcrumb-item
+      = link_to "Authors", [ :authors ]
+    %li.breadcrumb-item.active{ aria: { current: "page" } }= @author.name
+
+= render 'form', author: @author

--- a/app/views/authors/index.html.haml
+++ b/app/views/authors/index.html.haml
@@ -1,7 +1,7 @@
 %section.container
   %h1.mb-3 Authors
 
-  .mb-3
+  #authors.mb-3
     .row.fw-bold.border-bottom
       .col ID
       .col Name

--- a/app/views/authors/index.html.haml
+++ b/app/views/authors/index.html.haml
@@ -14,5 +14,6 @@
         .col.d-flex.gap-2
           = link_to "edit", [:edit, author], class: "link-primary"
 
-  .d-flex.w-100.align-items-center.justify-content-end.gap-2
-    = link_to "New author", [:new, :author], class: "btn btn-sm btn-primary"
+  %turbo-frame{ id: "new_author_frame" }
+    .d-flex.w-100.align-items-center.justify-content-end.gap-2
+      = link_to "New author", [:new, :author], class: "btn btn-sm btn-primary", data: { turbo_stream: true }

--- a/app/views/authors/index.html.haml
+++ b/app/views/authors/index.html.haml
@@ -7,13 +7,8 @@
       .col Name
       .col.gap-2
         Actions
-    - @authors.each do |author|
-      .row.d-flex.border-bottom.py-3
-        .col.fw-bold= author.id
-        .col= author.name
-        .col.d-flex.gap-2
-          = link_to "edit", [:edit, author], class: "link-primary"
+    = render @authors
 
-  %turbo-frame{ id: "new_author_frame" }
+  = turbo_frame_tag "new_author_frame" do
     .d-flex.w-100.align-items-center.justify-content-end.gap-2
       = link_to "New author", [:new, :author], class: "btn btn-sm btn-primary", data: { turbo_stream: true }

--- a/app/views/authors/index.html.haml
+++ b/app/views/authors/index.html.haml
@@ -1,4 +1,18 @@
 %section.container
   %h1.mb-3 Authors
-  - @authors.each do |author|
-    %pre= author.inspect
+
+  .mb-3
+    .row.fw-bold.border-bottom
+      .col ID
+      .col Name
+      .col.gap-2
+        Actions
+    - @authors.each do |author|
+      .row.d-flex.border-bottom.py-3
+        .col.fw-bold= author.id
+        .col= author.name
+        .col.d-flex.gap-2
+          = link_to "edit", [:edit, author], class: "link-primary"
+
+  .d-flex.w-100.align-items-center.justify-content-end.gap-2
+    = link_to "New author", [:new, :author], class: "btn btn-sm btn-primary"

--- a/app/views/authors/new.html.haml
+++ b/app/views/authors/new.html.haml
@@ -4,4 +4,5 @@
       = link_to "Authors", [ :authors ]
     %li.breadcrumb-item.active{ aria: { current: "page" } } New author
 
-= render 'form', author: @author
+%turbo-frame{ id: "new_author_frame" }
+  = render 'form', author: @author

--- a/app/views/authors/new.html.haml
+++ b/app/views/authors/new.html.haml
@@ -4,5 +4,5 @@
       = link_to "Authors", [ :authors ]
     %li.breadcrumb-item.active{ aria: { current: "page" } } New author
 
-%turbo-frame{ id: "new_author_frame" }
+= turbo_frame_tag "new_author_frame" do
   = render 'form', author: @author

--- a/app/views/authors/new.html.haml
+++ b/app/views/authors/new.html.haml
@@ -1,0 +1,7 @@
+%nav{aria: { label: "breadcrumb" } }
+  %ol.breadcrumb
+    %li.breadcrumb-item
+      = link_to "Authors", [ :authors ]
+    %li.breadcrumb-item.active{ aria: { current: "page" } } New author
+
+= render 'form', author: @author

--- a/app/views/layouts/_canvas.html.haml
+++ b/app/views/layouts/_canvas.html.haml
@@ -1,0 +1,5 @@
+= turbo_frame_tag "canvas", class: "position-relative h-100 bg-body-secondary border-left shadow-sm", refresh: "morph" do
+  .position-absolute.top-0.end-0.p-3
+    = button_to "", canvas_path, method: :delete, class: "btn btn-close"
+  .canvas-body
+    = yield "canvas"

--- a/app/views/layouts/_flash.html.haml
+++ b/app/views/layouts/_flash.html.haml
@@ -1,5 +1,5 @@
 - if flash.key?('alert')
-  .alert.alert-warning.alert-dismissable.d-flex(role="alert")
+  .alert.alert-danger.alert-dismissable.d-flex(role="alert")
     %span.flex-grow-1= flash[:alert]
     %button.btn-close(type="button" data-bs-dismiss="alert" aria-label="close")
 


### PR DESCRIPTION
Le but de cet exercice est de découvrir l'utilisation de Turbo Drive, Turbo Frame et Turbo Stream dans un environnement simple en ajoutant la gestion des auteurs dans Turbo Books. L'exercice suit la méthode de l'amélioration progressive. Commencez en implémentant un CRUD Rails classique puis utilisez Turbo pour améliorer l'expérience utilisateur.

## Étape 1 - CRUD classique

- Ajoutez les actions `edit`, `new`, `create`, `update` et `destroy` (l'édition fait office de `show`)
	- CRUD classique Rails : les actions `new` et `edit` ont leur page dédiée
	- Veillez à gérer et afficher les erreurs de validation

## Étape 2 - Formulaire sur la même page

- Utilisez Turbo Frame pour faire en sorte que le bouton "New Author" ne dirige plus vers une nouvelle page mais fasse apparaître le formulaire de création à la place du bouton.
	- Que se passe-t-il lors de la redirection du `create` ? Quelles sont les solutions envisageables pour corriger le problème ?

## Étape 3 - Insertion dynamique des nouveaux auteurs 

- Utilisez Turbo Stream pour ajouter le nouvel auteur à la page après la soumission du formulaire plutôt que de rediriger vers la page d'édition.
- Notez qu'il serait plus simple de rediriger vers l'index après la création, on perdrait le contexte de la page courante mais le trade-off est acceptable dans de nombreux cas

## Étape 4 - Refacto avec helpers et conventions 

- Refactorisez en utilisant les bonnes conventions Rails, des partials et les helpers fournit par la gem `turbo-rails`
- Profitez-en pour ajouter un lien de suppression avec confirmation